### PR TITLE
Add THINKPAD_BACKLIGHT_CHANGED event: 0x6050

### DIFF
--- a/YogaSMC/YogaVPC/ThinkEvents.h
+++ b/YogaSMC/YogaVPC/ThinkEvents.h
@@ -82,6 +82,7 @@ enum tpacpi_hkey_event_t : UInt32 {
     TP_HKEY_EV_THM_CSM_COMPLETED    = 0x6032, /* windows; thermal control set
                            * command completed. Related to
                            * AML DYTC */
+    TP_HKEY_EV_BACKLIGHT_CHANGED     = 0x6050, /* backlight changed */
     TP_HKEY_EV_LID_STATUS_CHANGED    = 0x60D0, /* lid status changed */
     TP_HKEY_EV_THM_TRANSFM_CHANGED   = 0x60F0, /* windows; thermal transformation
                            * changed. Related to AML GMTS */

--- a/YogaSMCNC/Configuration.swift
+++ b/YogaSMCNC/Configuration.swift
@@ -100,5 +100,7 @@ let ThinkEvents : Dictionary<UInt32, Dictionary<UInt32, eventDesc>> = [
                                     1: eventDesc("Keyboard Enabled", .Keyboard)], // 0x1315
     TP_HKEY_EV_THM_TABLE_CHANGED.rawValue : [0: eventDesc("Thermal Table Change", display: false)], // 0x6030
     TP_HKEY_EV_AC_CHANGED.rawValue: [0: eventDesc("AC Status Change", display: false)], // 0x6040
+    TP_HKEY_EV_BRGHT_UP.rawValue : [0: eventDesc("Brightness Up", display: false)], // 0x6050
+    TP_HKEY_EV_BRGHT_DOWN.rawValue : [0: eventDesc("Brightness Down", display: false)], // 0x6050
     TP_HKEY_EV_KEY_FN_ESC.rawValue : [0: eventDesc("FnLock", .FunctionKey)], // 0x6060
 ]

--- a/YogaSMCNC/Configuration.swift
+++ b/YogaSMCNC/Configuration.swift
@@ -100,6 +100,6 @@ let ThinkEvents : Dictionary<UInt32, Dictionary<UInt32, eventDesc>> = [
                                     1: eventDesc("Keyboard Enabled", .Keyboard)], // 0x1315
     TP_HKEY_EV_THM_TABLE_CHANGED.rawValue : [0: eventDesc("Thermal Table Change", display: false)], // 0x6030
     TP_HKEY_EV_AC_CHANGED.rawValue: [0: eventDesc("AC Status Change", display: false)], // 0x6040
-    TP_HKEY_EV_BACKLIGHT_CHANGED.rawValue : [0: eventDesc("Thinkpad Backlight Changed", display: false)], // 0x6050
+    TP_HKEY_EV_BACKLIGHT_CHANGED.rawValue : [0: eventDesc("Backlight Changed", display: false)], // 0x6050
     TP_HKEY_EV_KEY_FN_ESC.rawValue : [0: eventDesc("FnLock", .FunctionKey)], // 0x6060
 ]

--- a/YogaSMCNC/Configuration.swift
+++ b/YogaSMCNC/Configuration.swift
@@ -100,6 +100,6 @@ let ThinkEvents : Dictionary<UInt32, Dictionary<UInt32, eventDesc>> = [
                                     1: eventDesc("Keyboard Enabled", .Keyboard)], // 0x1315
     TP_HKEY_EV_THM_TABLE_CHANGED.rawValue : [0: eventDesc("Thermal Table Change", display: false)], // 0x6030
     TP_HKEY_EV_AC_CHANGED.rawValue: [0: eventDesc("AC Status Change", display: false)], // 0x6040
-    THINKPAD_BACKLIGHT_CHANGED.rawValue : [0: eventDesc("Thinkpad Backlight Changed", display: false)], // 0x6050
+    TP_HKEY_EV_BACKLIGHT_CHANGED.rawValue : [0: eventDesc("Thinkpad Backlight Changed", display: false)], // 0x6050
     TP_HKEY_EV_KEY_FN_ESC.rawValue : [0: eventDesc("FnLock", .FunctionKey)], // 0x6060
 ]

--- a/YogaSMCNC/Configuration.swift
+++ b/YogaSMCNC/Configuration.swift
@@ -100,7 +100,6 @@ let ThinkEvents : Dictionary<UInt32, Dictionary<UInt32, eventDesc>> = [
                                     1: eventDesc("Keyboard Enabled", .Keyboard)], // 0x1315
     TP_HKEY_EV_THM_TABLE_CHANGED.rawValue : [0: eventDesc("Thermal Table Change", display: false)], // 0x6030
     TP_HKEY_EV_AC_CHANGED.rawValue: [0: eventDesc("AC Status Change", display: false)], // 0x6040
-    TP_HKEY_EV_BRGHT_UP.rawValue : [0: eventDesc("Brightness Up", display: false)], // 0x6050
-    TP_HKEY_EV_BRGHT_DOWN.rawValue : [0: eventDesc("Brightness Down", display: false)], // 0x6050
+    THINKPAD_BACKLIGHT_CHANGED.rawValue : [0: eventDesc("Thinkpad Backlight Changed", display: false)], // 0x6050
     TP_HKEY_EV_KEY_FN_ESC.rawValue : [0: eventDesc("FnLock", .FunctionKey)], // 0x6060
 ]


### PR DESCRIPTION
Add event 0x6050 : THINKPAD_BACKLIGHT_CHANGED
To have working Brightness Keys on Lenovo ThinkPad(s): T440,T440S,X240