### PR TITLE
NC: Silence TP_HKEY_EV_LID_OPEN event: 0x5002

### DIFF
--- a/YogaSMCNC/Configuration.swift
+++ b/YogaSMCNC/Configuration.swift
@@ -98,6 +98,7 @@ let ThinkEvents : Dictionary<UInt32, Dictionary<UInt32, eventDesc>> = [
     TP_HKEY_EV_BLUETOOTH.rawValue : [0: eventDesc("Bluetooth", action: .bluetooth)], // 0x1314
     TP_HKEY_EV_KEYBOARD.rawValue : [0: eventDesc("Keyboard Disabled", .KeyboardOff),
                                     1: eventDesc("Keyboard Enabled", .Keyboard)], // 0x1315
+    TP_HKEY_EV_LID_OPEN.rawValue : [0: eventDesc("LID Open", display: false)], // 0x5002
     TP_HKEY_EV_THM_TABLE_CHANGED.rawValue : [0: eventDesc("Thermal Table Change", display: false)], // 0x6030
     TP_HKEY_EV_AC_CHANGED.rawValue: [0: eventDesc("AC Status Change", display: false)], // 0x6040
     TP_HKEY_EV_BACKLIGHT_CHANGED.rawValue : [0: eventDesc("Backlight Changed", display: false)], // 0x6050


### PR DESCRIPTION
For some reasons, the first sleep attempt after a reboot does instantly wake, if I open the LID fast I can catch the event 0x5002 notification from YogaSMC being shown.
If I leave the LID closed even if it does wake, after a few other attempts it will go to sleep as it should

Not sure if this PR is actually necessary or if it points out to a possible cause of instant wake, however feel free to open/close/merge as you think it should be.

Thanks !