### PR TITLE
NC: Silence OSD Notification for Palm Detection

### DIFF
--- a/YogaSMCNC/Configuration.swift
+++ b/YogaSMCNC/Configuration.swift
@@ -102,4 +102,6 @@ let ThinkEvents : Dictionary<UInt32, Dictionary<UInt32, eventDesc>> = [
     TP_HKEY_EV_AC_CHANGED.rawValue: [0: eventDesc("AC Status Change", display: false)], // 0x6040
     TP_HKEY_EV_BACKLIGHT_CHANGED.rawValue : [0: eventDesc("Backlight Changed", display: false)], // 0x6050
     TP_HKEY_EV_KEY_FN_ESC.rawValue : [0: eventDesc("FnLock", .FunctionKey)], // 0x6060
+    TP_HKEY_EV_PALM_DETECTED.rawValue : [0: eventDesc("Palm Detected", display: false)], // 0x60B0
+    TP_HKEY_EV_PALM_UNDETECTED.rawValue : [0: eventDesc("Palm Undetected", display: false)], // 0x60B1
 ]


### PR DESCRIPTION
Per Gitter discussion,

I think the OSD notification for palm detection should be silenced until an application is decided on. Right now, it can be quite annoying for the notification to keep appearing when using trackpad.