### PR TITLE
IdeaVPC: add workaround to extract battery cycle and ID

### DIFF
--- a/YogaSMC/WMI.cpp
+++ b/YogaSMC/WMI.cpp
@@ -49,10 +49,10 @@ extern "C" int ds_dec(void* pin,int lin, void* pout, int lout, int flg);
 // Convert UUID to little endian
 void le_uuid_dec(uuid_t *in, uuid_t *out)
 {
-    *((uint32_t *)out + 0) = OSSwapInt32(*((uint32_t *)in + 0));
-    *((uint16_t *)out + 2) = OSSwapInt16(*((uint16_t *)in + 2));
-    *((uint16_t *)out + 3) = OSSwapInt16(*((uint16_t *)in + 3));
-    *((uint64_t *)out + 1) =            (*((uint64_t *)in + 1));
+    *(reinterpret_cast<uint32_t *>(out) + 0) = OSSwapInt32(*(reinterpret_cast<uint32_t *>(in) + 0));
+    *(reinterpret_cast<uint16_t *>(out) + 2) = OSSwapInt16(*(reinterpret_cast<uint16_t *>(in) + 2));
+    *(reinterpret_cast<uint16_t *>(out) + 3) = OSSwapInt16(*(reinterpret_cast<uint16_t *>(in) + 3));
+    *(reinterpret_cast<uint64_t *>(out) + 1) =            (*(reinterpret_cast<uint64_t *>(in) + 1));
 }
 
 // parseWMIFlags - Parse WMI flags to a string

--- a/YogaSMC/YogaVPC.cpp
+++ b/YogaSMC/YogaVPC.cpp
@@ -659,12 +659,12 @@ IOReturn YogaVPC::message(UInt32 type, IOService *provider, void *argument) {
             if (!argument)
                 AlwaysLog("message: Unknown ACPI notification");
             else
-                AlwaysLog("message: Unknown ACPI notification 0x%04x", *((UInt32 *) argument));
+                AlwaysLog("message: Unknown ACPI notification 0x%04x", *(reinterpret_cast<UInt32 *>(argument)));
             break;
 
         default:
             if (argument)
-                AlwaysLog("message: type=%x, provider=%s, argument=0x%04x", type, provider->getName(), *((UInt32 *) argument));
+                AlwaysLog("message: type=%x, provider=%s, argument=0x%04x", type, provider->getName(), *(reinterpret_cast<UInt32 *>(argument)));
             else
                 AlwaysLog("message: type=%x, provider=%s", type, provider->getName());
     }

--- a/YogaSMC/YogaVPC/DYVPC.cpp
+++ b/YogaSMC/YogaVPC/DYVPC.cpp
@@ -135,7 +135,7 @@ IOReturn DYVPC::message(UInt32 type, IOService *provider, void *argument) {
     if (type != kIOACPIMessageDeviceNotification || !argument)
         return super::message(type, provider, argument);
 
-    updateVPC(*((UInt32 *) argument));
+    updateVPC(*(reinterpret_cast<UInt32 *>(argument)));
 
     return kIOReturnSuccess;
 }

--- a/YogaSMC/YogaVPC/IdeaVPC.cpp
+++ b/YogaSMC/YogaVPC/IdeaVPC.cpp
@@ -454,7 +454,7 @@ bool IdeaVPC::updateBatteryID(OSDictionary *bat0, OSDictionary *bat1) {
         setPropertyString(bat1, "Cycle count", batString);
         DebugLog("Battery 1 cycle count %d", cycle);
     } else {
-        AlwaysLog("Battery 1 cycle not exist");
+        DebugLog("Battery 1 cycle not exist");
     }
 
     UInt64 id;

--- a/YogaSMC/YogaVPC/IdeaVPC.hpp
+++ b/YogaSMC/YogaVPC/IdeaVPC.hpp
@@ -236,10 +236,21 @@ private:
     bool updateBatteryID(OSDictionary *bat0, OSDictionary *bat1);
 
     /**
+     *  Extract battery information
+     *
+     *  @param index Battery index
+     *
+     *  @return raw battery info
+     */
+    OSData *extractBatteryInfo(UInt32 index);
+
+    /**
      *  Update battery information
      *
      *  @param bat0 Dictionary for Battery 0
      *  @param bat1 Dictionary for Battery 1
+     *
+     *  @return true if success
      */
     bool updateBatteryInfo(OSDictionary *bat0, OSDictionary *bat1);
 

--- a/YogaSMC/YogaVPC/ThinkVPC.cpp
+++ b/YogaSMC/YogaVPC/ThinkVPC.cpp
@@ -722,7 +722,7 @@ IOReturn ThinkVPC::message(UInt32 type, IOService *provider, void *argument) {
             break;
 
         case kIOACPIMessageDeviceNotification:
-            if (argument && *((UInt32 *) argument) == kIOACPIMessageReserved) {
+            if (argument && *(reinterpret_cast<UInt32 *>(argument)) == kIOACPIMessageReserved) {
                 updateVPC();
                 break;
             }

--- a/YogaSMC/YogaVPC/YogaHIDD.cpp
+++ b/YogaSMC/YogaVPC/YogaHIDD.cpp
@@ -87,7 +87,7 @@ IOReturn YogaHIDD::message(UInt32 type, IOService *provider, void *argument) {
     if (type != kIOACPIMessageDeviceNotification || !argument)
         return super::message(type, provider, argument);
 
-    UInt32 event = *(reinterpret_cast<uint32_t *>(argument));
+    UInt32 event = *(reinterpret_cast<UInt32 *>(argument));
     DebugLog("message: type=%x, provider=%s, argument=0x%04x", type, provider->getName(), event);
     switch (event) {
         case 0xc0: // HID events

--- a/YogaSMC/YogaWMI.cpp
+++ b/YogaSMC/YogaWMI.cpp
@@ -137,14 +137,14 @@ IOReturn YogaWMI::message(UInt32 type, IOService *provider, void *argument) {
     {
         case kIOACPIMessageDeviceNotification:
             if (argument)
-                ACPIEvent(*(UInt32 *) argument);
+                ACPIEvent(*(reinterpret_cast<UInt32 *>(argument)));
             else
                 AlwaysLog("message: ACPI provider=%s, unknown argument", provider->getName());
             break;
 
         default:
             if (argument)
-                AlwaysLog("message: type=%x, provider=%s, argument=0x%04x", type, provider->getName(), *((UInt32 *) argument));
+                AlwaysLog("message: type=%x, provider=%s, argument=0x%04x", type, provider->getName(), *(reinterpret_cast<UInt32 *>(argument)));
             else
                 AlwaysLog("message: type=%x, provider=%s, unknown argument", type, provider->getName());
     }


### PR DESCRIPTION
CreateField (Create Arbitrary Length Buffer Field) returns number instead of buffer type in `GBID`.